### PR TITLE
fixed "# TODO: may want to also do 'interpolate' on frame_status (e.g find nearest neighbor and get corresponding frame_status flag)."

### DIFF
--- a/Utility/Trajectory.py
+++ b/Utility/Trajectory.py
@@ -170,9 +170,7 @@ class Trajectory:
         return MotionSequence(motions, duration, self.frame_status[1:], pp.SE3(self.poses[0]), start_time)
 
     def align_time(self, new_time: torch.Tensor) -> Trajectory:
-        aligned_pose, frame_status = interpolate_pose(self.poses, self.time, new_time)
-        # TODO: may want to also do 'interpolate' on frame_status (e.g. find nearest neighbor and 
-        # get corresponding frame_status flag).
+        aligned_pose, frame_status = interpolate_pose(self.poses, self.time, new_time, self.frame_status)
         return Trajectory(aligned_pose, new_time, frame_status)
 
     def align_SE3(self, ref_traj: Trajectory) -> Trajectory:


### PR DESCRIPTION
### **Utility and Trajectory Handling Improvements**

This PR introduces enhancements to the utility and trajectory modules to improve the handling and propagation of frame status information during interpolation and alignment operations.

#### 🔧 Changes:
- **`Utility/Math.py`**
  - Enhanced the `interpolate_pose` function to propagate `frame_status` during interpolation.
  - Ensures that alignment and interpolation preserve lost-frame information.

- **`Utility/Trajectory.py`**
  - Updated trajectory alignment and time alignment functions to pass and handle `frame_status`.
  - Maintains consistency of status flags throughout transformations.

#### 🧠 Logic for Frame Status Assignment:
- If a frame **already existed**, its `frame_status` is preserved from the `frame_status` file.
- If a frame is **generated via interpolation**, its `track_loss` is explicitly set to `False`.
